### PR TITLE
Fix of SVG support for Batik 1.9

### DIFF
--- a/jeuclid-core/pom.xml
+++ b/jeuclid-core/pom.xml
@@ -166,6 +166,11 @@
 		</dependency>
 		<dependency>
 			<groupId>org.apache.xmlgraphics</groupId>
+			<artifactId>batik-anim</artifactId>
+			<version>${batik.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.xmlgraphics</groupId>
 			<artifactId>batik-ext</artifactId>
 			<version>${batik.version}</version>
 			<exclusions>

--- a/jeuclid-core/src/main/java/net/sourceforge/jeuclid/converter/BatikDetector.java
+++ b/jeuclid-core/src/main/java/net/sourceforge/jeuclid/converter/BatikDetector.java
@@ -51,7 +51,7 @@ public final class BatikDetector implements ConverterDetector {
         try {
             final Class<?> svgdomimpl = ClassLoaderSupport.getInstance()
                     .loadClass(
-                            "org.apache.batik.dom.svg.SVGDOMImplementation");
+                            "org.apache.batik.anim.dom.SVGDOMImplementation");
             final Method getDOMimpl = svgdomimpl.getMethod(
                     "getDOMImplementation", new Class<?>[] {});
             impl = (DOMImplementation) getDOMimpl.invoke(null,


### PR DESCRIPTION
`SVGDOMImplementation` has moved to `org.apache.batik.anim.dom` (cd. https://stackoverflow.com/questions/30092651/where-has-org-apache-batik-dom-svg-svgdomimplementation-gone)