### PR TITLE
FOP plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ JEuclid
 =========
 
 This is a fork of http://jeuclid.sourceforge.net/ to get it working on JDK 9 and 
-with Batik 1.9. Only the core is supported.
+with Batik 1.9. Only the core and the FOP plugin are supported.
 
 FOP and SWT support is removed at the moment. If you need them or need any other feature
 not provided with this distribution, feel free to send me a pull request.

--- a/jeuclid-core/src/main/java/net/sourceforge/jeuclid/converter/ConverterRegistry.java
+++ b/jeuclid-core/src/main/java/net/sourceforge/jeuclid/converter/ConverterRegistry.java
@@ -52,10 +52,10 @@ public final class ConverterRegistry {
      */
     @SuppressWarnings("unchecked")
     protected ConverterRegistry() {
-        final Iterator<ConverterDetector> it = Service
+        final Iterator<Object> it = Service
                 .providers(ConverterDetector.class);
         while (it.hasNext()) {
-            final ConverterDetector det = it.next();
+            final ConverterDetector det = (ConverterDetector) it.next();
             det.detectConversionPlugins(this);
         }
     }

--- a/jeuclid-fop/pom.xml
+++ b/jeuclid-fop/pom.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>jeuclid-fop</artifactId>
+    <name>JEuclid FOP Plugin</name>
+    <parent>
+        <groupId>de.rototor.jeuclid</groupId>
+        <artifactId>jeuclid-parent</artifactId>
+        <version>3.1.14-SNAPSHOT</version>
+    </parent>
+    <description>This module contains the FOP plugin to support MathML in FOP through JEuclid.
+    </description>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven-compiler-plugin.version}</version>
+                <configuration>
+                    <source>1.6</source>
+                    <target>1.6</target>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>${maven-bundle-plugin.version}</version>
+                <configuration>
+                    <instructions>
+                        <Export-Package>net.sourceforge.jeuclid.fop.plugin</Export-Package>
+                    </instructions>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>${maven-jar-plugin.version}</version>
+                <configuration>
+                    <archive>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                    </archive>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <version>1.6</version>
+                <executions>
+                    <execution>
+                        <id>sign-artifacts</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>sign</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>3.0.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <version>1.6.7</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <serverId>ossrh</serverId>
+                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>2.5.3</version>
+                <configuration>
+                    <autoVersionSubmodules>true</autoVersionSubmodules>
+                    <useReleaseProfile>false</useReleaseProfile>
+                    <releaseProfiles>release</releaseProfiles>
+                    <goals>deploy</goals>
+                    <pushChanges>false</pushChanges>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>de.rototor.jeuclid</groupId>
+            <artifactId>jeuclid-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.xmlgraphics</groupId>
+            <artifactId>fop</artifactId>
+            <version>${fop.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/jeuclid-fop/src/main/java/net/sourceforge/jeuclid/fop/JEuclidElement.java
+++ b/jeuclid-fop/src/main/java/net/sourceforge/jeuclid/fop/JEuclidElement.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2007 - 2008 JEuclid, http://jeuclid.sf.net
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* $Id$ */
+
+/*
+ * Please note: This file was originally taken from the Apache FOP project,
+ * available at http://xmlgraphics.apache.org/fop/ It is therefore
+ * partially copyright (c) 1999-2007 The Apache Software Foundation.
+ * 
+ * Parts of the contents are heavily inspired by work done for Barcode4J by
+ * Jeremias Maerki, available at http://barcode4j.sf.net/
+ */
+
+package net.sourceforge.jeuclid.fop;
+
+import java.awt.Color;
+import java.awt.geom.Point2D;
+import java.util.ArrayList;
+import java.util.List;
+
+import net.sourceforge.jeuclid.Constants;
+import net.sourceforge.jeuclid.MutableLayoutContext;
+import net.sourceforge.jeuclid.context.LayoutContextImpl;
+import net.sourceforge.jeuclid.context.Parameter;
+import net.sourceforge.jeuclid.layout.JEuclidView;
+import net.sourceforge.jeuclid.xmlgraphics.PreloaderMathML;
+
+import org.apache.fop.apps.FOPException;
+import org.apache.fop.apps.FOUserAgent;
+import org.apache.fop.datatypes.Length;
+import org.apache.fop.fo.FOEventHandler;
+import org.apache.fop.fo.FONode;
+import org.apache.fop.fo.PropertyList;
+import org.apache.fop.fo.properties.CommonFont;
+import org.apache.fop.fo.properties.FixedLength;
+import org.apache.fop.fo.properties.Property;
+import org.apache.fop.fonts.FontInfo;
+import org.apache.fop.fonts.FontTriplet;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.xml.sax.Attributes;
+import org.xml.sax.Locator;
+
+/**
+ * Defines the top-level element for MathML.
+ * 
+ * @version $Revision$
+ */
+public class JEuclidElement extends JEuclidObj {
+
+    private Point2D size;
+
+    private Length baseline;
+
+    private final MutableLayoutContext layoutContext;
+
+    /**
+     * Default constructor.
+     * 
+     * @param parent
+     *            Parent Node in the FO tree.
+     */
+    public JEuclidElement(final FONode parent) {
+        super(parent);
+        this.layoutContext = new LayoutContextImpl(LayoutContextImpl
+                .getDefaultLayoutContext());
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void processNode(final String elementName, final Locator locator,
+            final Attributes attlist, final PropertyList propertyList)
+            throws FOPException {
+        super.processNode(elementName, locator, attlist, propertyList);
+        final Document d = this.createBasicDocument();
+        final Element e = d.getDocumentElement();
+        for (final Parameter p : Parameter.values()) {
+            final String localName = p.getOptionName();
+            final String attrName = "jeuclid:" + localName;
+            final String isSet = e.getAttributeNS(Constants.NS_JEUCLID_EXT,
+                    localName);
+            if ((isSet == null) || (isSet.length() == 0)) {
+                e.setAttributeNS(Constants.NS_JEUCLID_EXT, attrName, p
+                        .toString(this.layoutContext.getParameter(p)));
+            }
+        }
+    }
+
+    private void calculate() {
+        final JEuclidView view = new JEuclidView(this.doc, this.layoutContext,
+                null);
+        final float descent = view.getDescentHeight();
+        this.size = new Point2D.Float(view.getWidth(), view.getAscentHeight()
+                + descent);
+        this.baseline = FixedLength.getInstance(-descent, "pt");
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Point2D getDimension(final Point2D view) {
+        if (this.size == null) {
+            this.calculate();
+        }
+        return this.size;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Length getIntrinsicAlignmentAdjust() {
+        if (this.baseline == null) {
+            this.calculate();
+        }
+        return this.baseline;
+    }
+
+    /** {@inheritDoc} */
+    @SuppressWarnings("unchecked")
+    @Override
+    protected PropertyList createPropertyList(final PropertyList pList,
+            final FOEventHandler foEventHandler) throws FOPException {
+        final FOUserAgent userAgent = this.getUserAgent();
+        final CommonFont commonFont = pList.getFontProps();
+        final float msize = (float) (commonFont.fontSize.getNumericValue() / PreloaderMathML.MPT_FACTOR);
+        final Property colorProp = pList
+                .get(org.apache.fop.fo.Constants.PR_COLOR);
+        if (colorProp != null) {
+            final Color color = colorProp.getColor(userAgent);
+            this.layoutContext.setParameter(Parameter.MATHCOLOR, color);
+        }
+        final Property bcolorProp = pList
+                .get(org.apache.fop.fo.Constants.PR_BACKGROUND_COLOR);
+        if (bcolorProp != null) {
+            final Color bcolor = bcolorProp.getColor(userAgent);
+            this.layoutContext.setParameter(Parameter.MATHBACKGROUND, bcolor);
+        }
+        final FontInfo fi = this.getFOEventHandler().getFontInfo();
+        final FontTriplet[] fontkeys = commonFont.getFontState(fi);
+
+        this.layoutContext.setParameter(Parameter.MATHSIZE, msize);
+        final List<String> defaultFonts = (List<String>) this.layoutContext
+                .getParameter(Parameter.FONTS_SERIF);
+        final List<String> newFonts = new ArrayList<String>(fontkeys.length
+                + defaultFonts.size());
+        for (final FontTriplet t : fontkeys) {
+            newFonts.add(t.getName());
+        }
+        newFonts.addAll(defaultFonts);
+        this.layoutContext.setParameter(Parameter.FONTS_SERIF, newFonts);
+        return super.createPropertyList(pList, foEventHandler);
+    }
+}

--- a/jeuclid-fop/src/main/java/net/sourceforge/jeuclid/fop/JEuclidElementMapping.java
+++ b/jeuclid-fop/src/main/java/net/sourceforge/jeuclid/fop/JEuclidElementMapping.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2007 - 2008 JEuclid, http://jeuclid.sf.net
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* $Id$ */
+
+/* 
+ * Please note: This file was originally taken from the Apache FOP project,
+ * available at http://xmlgraphics.apache.org/fop/ It is therefore
+ * partially copyright (c) 1999-2007 The Apache Software Foundation.
+ * 
+ * Parts of the contents are heavily inspired by work done for Barcode4J by
+ * Jeremias Maerki, available at http://barcode4j.sf.net/
+ */
+
+package net.sourceforge.jeuclid.fop;
+
+import java.util.HashMap;
+
+import net.sourceforge.jeuclid.elements.AbstractJEuclidElement;
+
+import org.apache.fop.fo.ElementMapping;
+import org.apache.fop.fo.FONode;
+import org.w3c.dom.DOMImplementation;
+
+/**
+ * This class provides the element mapping for FOP.
+ * 
+ * @version $Revision$
+ */
+public class JEuclidElementMapping extends ElementMapping {
+
+    /** Main constructor. */
+    public JEuclidElementMapping() {
+        this.namespaceURI = AbstractJEuclidElement.URI;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public DOMImplementation getDOMImplementation() {
+        return ElementMapping.getDefaultDOMImplementation();
+    }
+
+    /** {@inheritDoc} */
+    @SuppressWarnings("unchecked")
+    @Override
+    protected void initialize() {
+        if (this.foObjs == null) {
+            this.foObjs = new HashMap();
+            this.foObjs.put("math", new ME());
+            this.foObjs.put(ElementMapping.DEFAULT, new MathMLMaker());
+
+        }
+    }
+
+    static final class MathMLMaker extends ElementMapping.Maker {
+
+        private MathMLMaker() {
+        }
+
+        @Override
+        public FONode make(final FONode parent) {
+            return new JEuclidObj(parent);
+        }
+    }
+
+    static final class ME extends ElementMapping.Maker {
+
+        private ME() {
+        }
+
+        @Override
+        public FONode make(final FONode parent) {
+            return new JEuclidElement(parent);
+        }
+    }
+
+}

--- a/jeuclid-fop/src/main/java/net/sourceforge/jeuclid/fop/JEuclidObj.java
+++ b/jeuclid-fop/src/main/java/net/sourceforge/jeuclid/fop/JEuclidObj.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2007 - 2007 JEuclid, http://jeuclid.sf.net
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* $Id$ */
+
+/*
+ * Please note: This file was originally taken from the Apache FOP project,
+ * available at http://xmlgraphics.apache.org/fop/ It is therefore
+ * partially copyright (c) 1999-2007 The Apache Software Foundation.
+ * 
+ * Parts of the contents are heavily inspired by work done for Barcode4J by
+ * Jeremias Maerki, available at http://barcode4j.sf.net/
+ */
+
+package net.sourceforge.jeuclid.fop;
+
+// FOP
+import net.sourceforge.jeuclid.elements.AbstractJEuclidElement;
+
+import org.apache.fop.fo.FONode;
+import org.apache.fop.fo.XMLObj;
+
+/**
+ * Catch all MathML objects as default element.
+ * 
+ * @version $Revision$
+ */
+public class JEuclidObj extends XMLObj {
+
+    /**
+     * Default constructor.
+     * 
+     * @param parent
+     *            Parent node in FO Tree
+     */
+    public JEuclidObj(final FONode parent) {
+        super(parent);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getNamespaceURI() {
+        return AbstractJEuclidElement.URI;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getNormalNamespacePrefix() {
+        return "mathml";
+    }
+}

--- a/jeuclid-fop/src/main/java/net/sourceforge/jeuclid/fop/JEuclidXMLHandler.java
+++ b/jeuclid-fop/src/main/java/net/sourceforge/jeuclid/fop/JEuclidXMLHandler.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2007 - 2008 JEuclid, http://jeuclid.sf.net
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* $Id$ */
+
+/* 
+ * Parts of the contents are heavily inspired by work done for Barcode4J by
+ * Jeremias Maerki, available at http://barcode4j.sf.net/
+ */
+package net.sourceforge.jeuclid.fop;
+
+import net.sourceforge.jeuclid.elements.AbstractJEuclidElement;
+import net.sourceforge.jeuclid.xmlgraphics.Graphics2DImagePainterMathML;
+
+import org.apache.fop.render.Graphics2DAdapter;
+import org.apache.fop.render.Renderer;
+import org.apache.fop.render.RendererContext;
+import org.apache.fop.render.XMLHandler;
+import org.apache.xmlgraphics.java2d.Graphics2DImagePainter;
+import org.w3c.dom.Document;
+
+/**
+ * XMLHandler which draws MathML through a fop G2DAdapter.
+ * 
+ * @version $Revision$
+ */
+public class JEuclidXMLHandler implements XMLHandler {
+
+    /** Creates a new instance of JEuclidXMLHandler. */
+    public JEuclidXMLHandler() {
+    }
+
+    /** {@inheritDoc} */
+    public void handleXML(final RendererContext rendererContext,
+            final Document document, final String ns) throws Exception {
+        final Graphics2DAdapter g2dAdapter = rendererContext.getRenderer()
+                .getGraphics2DAdapter();
+
+        if (g2dAdapter != null) {
+            final Graphics2DImagePainter painter = Graphics2DImagePainterMathML
+                    .createGraphics2DImagePainter(document);
+            g2dAdapter.paintImage(painter, rendererContext,
+                    ((Integer) rendererContext.getProperty("xpos"))
+                            .intValue(), ((Integer) rendererContext
+                            .getProperty("ypos")).intValue(),
+                    ((Integer) rendererContext.getProperty("width"))
+                            .intValue(), ((Integer) rendererContext
+                            .getProperty("height")).intValue());
+
+        }
+    }
+
+    /** {@inheritDoc} */
+    public boolean supportsRenderer(final Renderer renderer) {
+        return renderer.getGraphics2DAdapter() != null;
+    }
+
+    /** {@inheritDoc} */
+    public String getNamespace() {
+        return AbstractJEuclidElement.URI;
+    }
+
+}

--- a/jeuclid-fop/src/main/java/net/sourceforge/jeuclid/fop/package-info.java
+++ b/jeuclid-fop/src/main/java/net/sourceforge/jeuclid/fop/package-info.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2007 - 2007 JEuclid, http://jeuclid.sf.net
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* $Id$ */
+
+/**
+ * Contains the fop plugin.
+ *
+ * <p>For information about fop, please see the 
+ * <a href="http://xmlgraphics.apache.org/fop/">FOP homepage</a></p>
+ */
+package net.sourceforge.jeuclid.fop;
+

--- a/jeuclid-fop/src/main/java/net/sourceforge/jeuclid/fop/plugin/JEuclidFopFactoryConfigurator.java
+++ b/jeuclid-fop/src/main/java/net/sourceforge/jeuclid/fop/plugin/JEuclidFopFactoryConfigurator.java
@@ -1,0 +1,22 @@
+package net.sourceforge.jeuclid.fop.plugin;
+
+import org.apache.fop.apps.FopFactory;
+
+public class JEuclidFopFactoryConfigurator {
+    public static void configure(final FopFactory fopFactory) {
+        fopFactory.getElementMappingRegistry().addElementMapping(
+                new net.sourceforge.jeuclid.fop.JEuclidElementMapping());
+        fopFactory.getXMLHandlerRegistry().addXMLHandler(
+                new net.sourceforge.jeuclid.fop.JEuclidXMLHandler());
+
+        final org.apache.xmlgraphics.image.loader.spi.ImageImplRegistry images =
+                fopFactory.getImageManager().getRegistry();
+
+        images.registerLoaderFactory(
+                new net.sourceforge.jeuclid.xmlgraphics.ImageLoaderFactoryMathML());
+        images.registerPreloader(
+                new net.sourceforge.jeuclid.xmlgraphics.PreloaderMathML());
+        images.registerConverter(
+                new net.sourceforge.jeuclid.xmlgraphics.ImageConverterMathML2G2D());
+    }
+}

--- a/jeuclid-fop/src/main/java/net/sourceforge/jeuclid/xmlgraphics/Graphics2DImagePainterMathML.java
+++ b/jeuclid-fop/src/main/java/net/sourceforge/jeuclid/xmlgraphics/Graphics2DImagePainterMathML.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2002 - 2008 JEuclid, http://jeuclid.sf.net
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* $Id$ */
+
+package net.sourceforge.jeuclid.xmlgraphics;
+
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import java.awt.geom.Rectangle2D;
+
+import net.sourceforge.jeuclid.MutableLayoutContext;
+import net.sourceforge.jeuclid.context.LayoutContextImpl;
+import net.sourceforge.jeuclid.layout.JEuclidView;
+
+import org.apache.xmlgraphics.java2d.Graphics2DImagePainter;
+import org.w3c.dom.Document;
+
+/**
+ * Actually draw an JEuclidView.
+ * 
+ * @version $Revision$
+ */
+public class Graphics2DImagePainterMathML implements Graphics2DImagePainter {
+
+    private final Dimension dimension;
+
+    private final JEuclidView view;
+
+    private final float ascent;
+
+    /**
+     * Default Constructor.
+     * 
+     * @param theView
+     *            {@link JEuclidView} to paint.
+     * @param dim
+     *            Dimension of the view.
+     * @param asc
+     *            Ascent of the view.
+     */
+    public Graphics2DImagePainterMathML(final JEuclidView theView,
+            final Dimension dim, final float asc) {
+        this.view = theView;
+        this.dimension = dim;
+        this.ascent = asc;
+    }
+
+    /**
+     * Create a new {@link Graphics2DImagePainter} for the given Document.
+     * 
+     * @param document
+     *            A MathML DOM Document.
+     * @return a {@link Graphics2DImagePainter}.
+     */
+    public static Graphics2DImagePainter createGraphics2DImagePainter(
+            final Document document) {
+        final MutableLayoutContext layoutContext = new LayoutContextImpl(
+                LayoutContextImpl.getDefaultLayoutContext());
+
+        final JEuclidView view = new JEuclidView(document, layoutContext,
+                null);
+        final int w = (int) Math.ceil(view.getWidth()
+                * PreloaderMathML.MPT_FACTOR);
+        final float ascent = view.getAscentHeight();
+        final int h = (int) Math.ceil((ascent + view.getDescentHeight())
+                * PreloaderMathML.MPT_FACTOR);
+        return new Graphics2DImagePainterMathML(view, new Dimension(w, h),
+                ascent);
+    }
+
+    /** {@inheritDoc} */
+    public Dimension getImageSize() {
+        return this.dimension;
+    }
+
+    /** {@inheritDoc} */
+    public void paint(final Graphics2D graphics2d,
+            final Rectangle2D rectangle2d) {
+        this.view.draw(graphics2d, 0, this.ascent);
+    }
+}

--- a/jeuclid-fop/src/main/java/net/sourceforge/jeuclid/xmlgraphics/ImageConverterMathML2G2D.java
+++ b/jeuclid-fop/src/main/java/net/sourceforge/jeuclid/xmlgraphics/ImageConverterMathML2G2D.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2002 - 2009 JEuclid, http://jeuclid.sf.net
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* $Id$ */
+
+package net.sourceforge.jeuclid.xmlgraphics;
+
+import java.util.Map;
+
+import org.apache.xmlgraphics.image.loader.Image;
+import org.apache.xmlgraphics.image.loader.ImageException;
+import org.apache.xmlgraphics.image.loader.ImageFlavor;
+import org.apache.xmlgraphics.image.loader.impl.AbstractImageConverter;
+import org.apache.xmlgraphics.image.loader.impl.ImageGraphics2D;
+import org.apache.xmlgraphics.image.loader.impl.ImageXMLDOM;
+import org.apache.xmlgraphics.java2d.Graphics2DImagePainter;
+
+/**
+ * Convert a MathML Image given as DOM to a Graphics2d Painter.
+ * 
+ * @version $Revision$
+ */
+public class ImageConverterMathML2G2D extends AbstractImageConverter {
+    /**
+     * Default Constructor.
+     */
+    public ImageConverterMathML2G2D() {
+        // Empty on purpose
+    }
+
+    /** {@inheritDoc} */
+    @SuppressWarnings("unchecked")
+    // Interface is not generic
+    public Image convert(final Image src, final Map hints)
+            throws ImageException {
+        // TODO: Should be checked
+        // this.checkSourceFlavor(src);
+        final ImageXMLDOM xmlDom = (ImageXMLDOM) src;
+        final Graphics2DImagePainter painter = Graphics2DImagePainterMathML
+                .createGraphics2DImagePainter(xmlDom.getDocument());
+
+        final ImageGraphics2D g2dImage = new ImageGraphics2D(src.getInfo(),
+                painter);
+        return g2dImage;
+    }
+
+    /** {@inheritDoc} */
+    public ImageFlavor getSourceFlavor() {
+        return ImageFlavor.XML_DOM;
+        // TODO: Use new namespace
+        // return new ImageFlavor(
+        // "text/xml;DOM;namespace=http://www.w3.org/1998/Math/MathML");
+    }
+
+    /** {@inheritDoc} */
+    public ImageFlavor getTargetFlavor() {
+        return ImageFlavor.GRAPHICS2D;
+    }
+
+}

--- a/jeuclid-fop/src/main/java/net/sourceforge/jeuclid/xmlgraphics/ImageLoaderFactoryMathML.java
+++ b/jeuclid-fop/src/main/java/net/sourceforge/jeuclid/xmlgraphics/ImageLoaderFactoryMathML.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2002 - 2008 JEuclid, http://jeuclid.sf.net
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* $Id$ */
+
+package net.sourceforge.jeuclid.xmlgraphics;
+
+import net.sourceforge.jeuclid.Constants;
+
+import org.apache.xmlgraphics.image.loader.ImageFlavor;
+import org.apache.xmlgraphics.image.loader.impl.AbstractImageLoaderFactory;
+import org.apache.xmlgraphics.image.loader.spi.ImageLoader;
+
+/**
+ * @version $Revision$
+ */
+public class ImageLoaderFactoryMathML extends AbstractImageLoaderFactory {
+
+    private static final ImageFlavor[] FLAVORS = new ImageFlavor[] { ImageFlavor.XML_DOM };
+
+    private static final String[] MIMES = new String[] { Constants.MATHML_MIMETYPE };
+
+    /**
+     * Default Constructor.
+     */
+    public ImageLoaderFactoryMathML() {
+        // Empty on purpose
+    }
+
+    /** {@inheritDoc} */
+    public String[] getSupportedMIMETypes() {
+        return ImageLoaderFactoryMathML.MIMES.clone();
+    }
+
+    /** {@inheritDoc} */
+    public ImageFlavor[] getSupportedFlavors(final String mime) {
+        return ImageLoaderFactoryMathML.FLAVORS.clone();
+    }
+
+    /** {@inheritDoc} */
+    public ImageLoader newImageLoader(final ImageFlavor targetFlavor) {
+        return new ImageLoaderMathML(targetFlavor);
+    }
+
+    /** {@inheritDoc} */
+    public int getUsagePenalty(final String mime, final ImageFlavor flavor) {
+        return 0;
+    }
+
+    /** {@inheritDoc} */
+    public boolean isAvailable() {
+        return true;
+    }
+
+}

--- a/jeuclid-fop/src/main/java/net/sourceforge/jeuclid/xmlgraphics/ImageLoaderMathML.java
+++ b/jeuclid-fop/src/main/java/net/sourceforge/jeuclid/xmlgraphics/ImageLoaderMathML.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2002 - 2008 JEuclid, http://jeuclid.sf.net
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* $Id$ */
+
+package net.sourceforge.jeuclid.xmlgraphics;
+
+import java.io.IOException;
+import java.util.Map;
+
+import net.sourceforge.jeuclid.Constants;
+import net.sourceforge.jeuclid.elements.AbstractJEuclidElement;
+
+import org.apache.xmlgraphics.image.loader.Image;
+import org.apache.xmlgraphics.image.loader.ImageException;
+import org.apache.xmlgraphics.image.loader.ImageFlavor;
+import org.apache.xmlgraphics.image.loader.ImageInfo;
+import org.apache.xmlgraphics.image.loader.ImageSessionContext;
+import org.apache.xmlgraphics.image.loader.impl.AbstractImageLoader;
+import org.apache.xmlgraphics.image.loader.impl.ImageXMLDOM;
+
+/**
+ * @version $Revision$
+ */
+public class ImageLoaderMathML extends AbstractImageLoader {
+
+    private final ImageFlavor targetFlavor;
+
+    /**
+     * Main constructor.
+     * 
+     * @param target
+     *            the target flavor
+     */
+    public ImageLoaderMathML(final ImageFlavor target) {
+        if (!(ImageFlavor.XML_DOM.equals(target))) {
+            throw new IllegalArgumentException(
+                    "Unsupported target ImageFlavor: " + target);
+        }
+        this.targetFlavor = target;
+    }
+
+    /** {@inheritDoc} */
+    public ImageFlavor getTargetFlavor() {
+        return this.targetFlavor;
+    }
+
+    /** {@inheritDoc} */
+    @SuppressWarnings("unchecked")
+    public Image loadImage(final ImageInfo info, final Map hints,
+            final ImageSessionContext session) throws ImageException,
+            IOException {
+        if (!Constants.MATHML_MIMETYPE.equals(info.getMimeType())) {
+            throw new IllegalArgumentException(
+                    "ImageInfo must be from an MathML image");
+        }
+        final Image img = info.getOriginalImage();
+        if (!(img instanceof ImageXMLDOM)) {
+            throw new IllegalArgumentException(
+                    "ImageInfo was expected to contain the MathML document as DOM");
+        }
+        final ImageXMLDOM mmlImage = (ImageXMLDOM) img;
+        if (!AbstractJEuclidElement.URI.equals(mmlImage.getRootNamespace())) {
+            throw new IllegalArgumentException(
+                    "The Image is not in the MathML namespace: "
+                            + mmlImage.getRootNamespace());
+        }
+        return mmlImage;
+    }
+}

--- a/jeuclid-fop/src/main/java/net/sourceforge/jeuclid/xmlgraphics/PreloaderMathML.java
+++ b/jeuclid-fop/src/main/java/net/sourceforge/jeuclid/xmlgraphics/PreloaderMathML.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2002 - 2008 JEuclid, http://jeuclid.sf.net
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* $Id$ */
+
+package net.sourceforge.jeuclid.xmlgraphics;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import javax.xml.transform.Source;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamSource;
+
+import net.sourceforge.jeuclid.Constants;
+import net.sourceforge.jeuclid.context.LayoutContextImpl;
+import net.sourceforge.jeuclid.elements.AbstractJEuclidElement;
+import net.sourceforge.jeuclid.elements.generic.MathImpl;
+import net.sourceforge.jeuclid.layout.JEuclidView;
+import net.sourceforge.jeuclid.parser.Parser;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.fop.util.UnclosableInputStream;
+import org.apache.xmlgraphics.image.loader.ImageContext;
+import org.apache.xmlgraphics.image.loader.ImageException;
+import org.apache.xmlgraphics.image.loader.ImageInfo;
+import org.apache.xmlgraphics.image.loader.ImageSize;
+import org.apache.xmlgraphics.image.loader.impl.AbstractImagePreloader;
+import org.apache.xmlgraphics.image.loader.impl.ImageXMLDOM;
+import org.apache.xmlgraphics.image.loader.util.ImageUtil;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.xml.sax.SAXException;
+
+/**
+ * @version $Revision$
+ */
+public class PreloaderMathML extends AbstractImagePreloader {
+    /**
+     * Convert from point to millipoint.
+     */
+    public static final float MPT_FACTOR = 1000.0f;
+
+    /**
+     * Logger for this class
+     */
+    private static final Log LOGGER = LogFactory
+            .getLog(PreloaderMathML.class);
+
+    /**
+     * Default Constructor.
+     */
+    public PreloaderMathML() {
+        // Empty on purpose
+    }
+
+    /** {@inheritDoc} */
+    public ImageInfo preloadImage(final String uri, final Source src,
+            final ImageContext context) throws ImageException, IOException {
+        final Document n = this.parseSource(src);
+        if (n != null) {
+            return this.createImageInfo(uri, context, n);
+        }
+
+        return null;
+    }
+
+    @SuppressWarnings("unchecked")
+    private ImageInfo createImageInfo(final String uri,
+            final ImageContext context, final Document n) {
+        final ImageInfo info = new ImageInfo(uri, Constants.MATHML_MIMETYPE);
+        final ImageSize size = new ImageSize();
+        final JEuclidView view = new JEuclidView(n, LayoutContextImpl
+                .getDefaultLayoutContext(), null);
+        final int descentMpt = (int) (view.getDescentHeight() * PreloaderMathML.MPT_FACTOR);
+        final int ascentMpt = (int) (view.getAscentHeight() * PreloaderMathML.MPT_FACTOR);
+
+        size.setSizeInMillipoints(
+                (int) (view.getWidth() * PreloaderMathML.MPT_FACTOR),
+                ascentMpt + descentMpt);
+        size.setBaselinePositionFromBottom(descentMpt);
+        // Set the resolution to that of the FOUserAgent
+        size.setResolution(context.getSourceResolution());
+        size.calcPixelsFromSize();
+        info.setSize(size);
+
+        // The whole image had to be loaded for this, so keep it
+        final ImageXMLDOM xmlImage = new ImageXMLDOM(info, n,
+                AbstractJEuclidElement.URI);
+        info.getCustomObjects().put(ImageInfo.ORIGINAL_IMAGE, xmlImage);
+        return info;
+    }
+
+    private Document parseSource(final Source src) {
+        Document n = null;
+        InputStream in = null;
+        try {
+            if (src instanceof DOMSource) {
+                final DOMSource domSrc = (DOMSource) src;
+                n = (Document) domSrc.getNode();
+            } else {
+                in = new UnclosableInputStream(ImageUtil.needInputStream(src));
+                final int length = in.available();
+                in.mark(length + 1);
+                n = Parser.getInstance().parseStreamSource(
+                        new StreamSource(in));
+            }
+            final Element rootNode = n.getDocumentElement();
+            if (!(AbstractJEuclidElement.URI.equals(rootNode
+                    .getNamespaceURI()) || MathImpl.ELEMENT.equals(rootNode
+                    .getNodeName()))) {
+                n = null;
+            }
+        } catch (final IOException e) {
+            n = null;
+        } catch (final SAXException e) {
+            n = null;
+        } catch (final IllegalArgumentException e) {
+            n = null;
+        } catch (final NullPointerException e) {
+            // Due to a bug in xmlgraphics-commons 1.3.1 which sometimes
+            // creates wrapper around null streams if files do not exist.
+            n = null;
+        }
+        try {
+            if (in != null) {
+                in.reset();
+            }
+        } catch (final IOException ioe) {
+            PreloaderMathML.LOGGER.warn("Should never happen: "
+                    + ioe.getMessage());
+        } catch (final NullPointerException e) {
+            // Due to a bug in xmlgraphics-commons 1.3.1 which sometimes
+            // creates wrapper around null streams if files do not exist.
+            n = null;
+        }
+        return n;
+    }
+}

--- a/jeuclid-fop/src/site/site.xml
+++ b/jeuclid-fop/src/site/site.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!-- 
+   Copyright 2007
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<project name="JEuclid">
+  <body>
+    <menu ref="parent"/>
+    <menu ref="reports"/>
+  </body>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,7 @@
 	<modules>
 		<module>jeuclid-core</module>
 		<module>jeuclid-testsuite</module>
+		<module>jeuclid-fop</module>
 	</modules>
 	<description>
 		This is a stripped down version of jeculid running with JDK 9 with Batik 1.9. Minimum Java requirement is 1.6.
@@ -467,7 +468,7 @@
 		<ams-fonts.version>1.0-2</ams-fonts.version>
 		<commons-cli.version>1.2</commons-cli.version>
 		<commons-lang3.version>3.0.1</commons-lang3.version>
-		<fop.version>1.0</fop.version>
+		<fop.version>2.3</fop.version>
 		<webstart-maven-plugin.version>1.0-beta-1</webstart-maven-plugin.version>
 		<osxappbundle-maven-plugin.version>1.0-alpha-1</osxappbundle-maven-plugin.version>
 		<maven-shade-plugin.version>1.4</maven-shade-plugin.version>


### PR DESCRIPTION
Thank you, @rototor, for all the hard work making JEuclid work with current libraries and JDKs!
I need JEuclid's FOP plugin in my project.
Turns out that local copy of the original sources of the plugin just works using your JEuclid artifact!
In case I am not the last person using the FOP plugin, maybe it can be distributed side-by-side with the core?

Changes:
- restored as-is original Java sources of the FOP plugin;
- did not restore ServiceLoader provider-configuration files under META-INF/services;
  with them, plugin would be auto-configured for all FOP runs;
  now it can be configured for a specific FopFactory using
  new class JEuclidFopFactoryConfigurator's configure() method;
- restored plugin's src/site/site.xml file;
- restored and cleaned up plugin's POM;
- packaging as an artifact that depends on the JEuclid core, not including it in the plugin JAR;
- re-added plugin module to the main POM and brought FOP version up-to-date.
