### PR TITLE
Fixed NPE if JMathComponent is created by empty constructor and later…

### DIFF
--- a/jeuclid-core/src/main/java/net/sourceforge/jeuclid/swing/JMathComponent.java
+++ b/jeuclid-core/src/main/java/net/sourceforge/jeuclid/swing/JMathComponent.java
@@ -103,9 +103,11 @@ public final class JMathComponent extends JComponent implements
     public JMathComponent(final CursorListener listener) {
         this.cursorListener = listener;
 
-        final JMathComponentMouseListener mouseListener = new JMathComponentMouseListener(
+        if (listener != null) {
+            final JMathComponentMouseListener mouseListener = new JMathComponentMouseListener(
                 this);
-        this.addMouseListener(mouseListener);
+            this.addMouseListener(mouseListener);
+        }
 
         this.updateUI();
         this.fontCompat();
@@ -545,7 +547,7 @@ public final class JMathComponent extends JComponent implements
     @Override
     public void updateUI() {
         if (UIManager.get(this.getUIClassID()) == null) {
-			this.setUI(new MathComponentUI16());
+            this.setUI(new MathComponentUI16());
         } else {
             this.setUI(UIManager.getUI(this));
         }

--- a/jeuclid-core/src/main/java/net/sourceforge/jeuclid/swing/JMathComponentMouseListener.java
+++ b/jeuclid-core/src/main/java/net/sourceforge/jeuclid/swing/JMathComponentMouseListener.java
@@ -27,7 +27,7 @@ import java.util.List;
 
 /**
  * A simple mouse listener for Graphics&lt;=&gt;Text association.
- * 
+ *
  * @version $Revision: $
  */
 public class JMathComponentMouseListener implements MouseListener {
@@ -39,18 +39,19 @@ public class JMathComponentMouseListener implements MouseListener {
 
     /**
      * standard constructor.
-     * 
+     *
      * @param mathComponentInstance
      *            math component instance
      */
     public JMathComponentMouseListener(
             final JMathComponent mathComponentInstance) {
         this.mathComponent = mathComponentInstance;
+        assert this.mathComponent.getCursorListener() != null : "Cursorlistener is required by JMathComponentMouseListener";
     }
 
     /**
      * mouse click event handler.
-     * 
+     *
      * @param e
      *            mouse event
      */
@@ -59,14 +60,16 @@ public class JMathComponentMouseListener implements MouseListener {
         final List<NodeRect> rectList = ui.getNodesAt(this.mathComponent, e.getX(), e.getY());
         if (rectList != null && rectList.size() > 0) {
             final Node lastNode = rectList.get(rectList.size() - 1).getNode();
-            this.mathComponent.getCursorListener().updateCursorPosition(
-                    lastNode);
+            final CursorListener cursorListener = this.mathComponent.getCursorListener();
+            if (cursorListener != null) {
+                cursorListener.updateCursorPosition(lastNode);
+            }
         }
     }
 
     /**
      * mouse pressed event (unused).
-     * 
+     *
      * @param e
      *            mouse event
      */
@@ -75,7 +78,7 @@ public class JMathComponentMouseListener implements MouseListener {
 
     /**
      * mouse pressed event (unused).
-     * 
+     *
      * @param e
      *            mouse event
      */
@@ -84,7 +87,7 @@ public class JMathComponentMouseListener implements MouseListener {
 
     /**
      * mouse pressed event (unused).
-     * 
+     *
      * @param e
      *            mouse event
      */
@@ -93,7 +96,7 @@ public class JMathComponentMouseListener implements MouseListener {
 
     /**
      * mouse pressed event (unused).
-     * 
+     *
      * @param e
      *            mouse event
      */


### PR DESCRIPTION
… the JMathComponent receives a MouseClicked event.

JMathComponentMouseListener now accepts cursorListener == null in normal execution flow but contains an assertion to throw an AssertionError if VM is started with -ea argument
JMathComponent(CursorListener) now creates cursorListener only if given listener is not null